### PR TITLE
pidcat version following PEP440

### DIFF
--- a/pidcat.py
+++ b/pidcat.py
@@ -29,7 +29,7 @@ import sys
 from subprocess import PIPE
 from collections import deque
 
-__version__ = '2.2.0-unofficial'
+__version__ = '2.2.0+unofficial'
 
 from typing import Pattern, List, Optional
 


### PR DESCRIPTION
Version was not following PEP440 as of: https://peps.python.org/pep-0440/#local-version-identifiers
Therefore not allowing the installation via `pipx`